### PR TITLE
deps: update pflag from v1.0.9 to v1.0.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,9 @@ jobs:
           version: latest
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0.2
+          version: v2.6.0
           args: --show-stats
 
   build:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,16 +8,23 @@ run:
 
 linters:
   default: all
+  enable:
+    - wsl_v5
   disable:
     - depguard
     - exhaustruct
     - forbidigo
     - gochecknoglobals
     - varnamelen
+    - wsl
   settings:
     paralleltest:
       ignore-missing: true
       ignore-missing-subtests: true
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
   exclusions:
     generated: lax
     presets:
@@ -26,9 +33,9 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      - linters:
-          - wsl
-        text: return statements should not be cuddled if block has more than two lines
+      # - linters:
+      #     - wsl
+      #   text: return statements should not be cuddled if block has more than two lines
       - linters:
           - funlen
           - lll

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,8 @@ See also:
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	err := rootCmd.Execute()
+	if err != nil {
 		var exitError *exec.ExitError
 
 		fmt.Printf("error: %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require github.com/spf13/cobra v1.10.1
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main_test.go
+++ b/main_test.go
@@ -68,7 +68,7 @@ func TestExitCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := exec.Command(binaryPath)
+			cmd := exec.Command(binaryPath) //nolint:noctx
 
 			cmd.Env = append(os.Environ(),
 				"BE_CRASHER=1",

--- a/pkg/gosemver/gosemver_test.go
+++ b/pkg/gosemver/gosemver_test.go
@@ -103,12 +103,14 @@ func TestCompareSemVer(t *testing.T) {
 
 				t.Errorf("CompareSemVer(%s, %s) = %v, want %v", tt.v1, tt.v2, got, tt.wantErr)
 				fmt.Println(err)
+
 				return
 			}
 
 			reverse, err := gosemver.CompareSemVer(tt.v2, tt.v1)
 			if err != nil {
 				t.Errorf("CompareSemVer() error = %v", err)
+
 				return
 			}
 

--- a/pkg/gosemver/utils.go
+++ b/pkg/gosemver/utils.go
@@ -16,8 +16,10 @@ func bumpExistingNumeric(existing string) string {
 	if numeric != "" {
 		oldNum, _ := strconv.Atoi(numeric)
 		oldNum++
+
 		return fmt.Sprintf("%s%d", prefix, oldNum)
 	}
+
 	// if there's no numeric part, append "1"
 	return fmt.Sprintf("%s1", prefix)
 }
@@ -37,9 +39,9 @@ func splitNumericSuffix(prerelease string) (string, string) {
 	}
 
 	if idx == len(prerelease)-1 {
-		// no trailing digits
-		return prerelease, ""
+		return prerelease, "" // no trailing digits
 	}
+
 	return prerelease[:idx+1], prerelease[idx+1:]
 }
 


### PR DESCRIPTION
This pull request introduces several updates to linting configuration, dependency management, code robustness, and testing practices. The most significant changes involve switching to the newer `wsl_v5` linter and adjusting its settings, updating a dependency version, and making minor improvements to code clarity and test annotations.

**Linting configuration updates:**

* Enabled the `wsl_v5` linter in `.golangci.yaml`, configured its behavior, and disabled the older `wsl` linter. This ensures more up-to-date linting checks and customizes rules for return statement cuddling and block line limits.
* Commented out the legacy `wsl` linter rule in `.golangci.yaml` to avoid redundancy and potential conflicts with `wsl_v5`.

**Dependency management:**

* Updated the `github.com/spf13/pflag` dependency from version `v1.0.9` to `v1.0.10` in `go.mod` for improved compatibility and bug fixes.

**Code robustness and clarity:**

* Refactored error handling in the `Execute` function in `cmd/root.go` for improved readability and maintainability.
* Added a `//nolint:noctx` annotation to a test command in `main_test.go` to suppress lint warnings where context is intentionally omitted.

Other minor changes include formatting and clarity improvements in utility and test files.